### PR TITLE
semicolon fix

### DIFF
--- a/lib/spielbash/model/session.rb
+++ b/lib/spielbash/model/session.rb
@@ -43,7 +43,11 @@ module Spielbash
     end
 
     def send_key(key, count=1)
-      key = 'Space' if key == ' '
+      key = case key
+              when ' ' then 'Space'
+              when ';' then '\\;'
+              else key
+            end
       execute_tmux_with("send-keys -t #{name} -N #{count} #{key}", true)
     end
 


### PR DESCRIPTION
Spielbash was unable to send semicolons.
They were treated by tmux as end of command.
This patch fixes this issue.